### PR TITLE
Pin terraform-aws-modules/vpc/aws version 3.7

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ data "aws_region" "current" {}
 #####################
 module "vpc" {
   source                                 = "terraform-aws-modules/vpc/aws"
+  version                                = "3.7"
   name                                   = var.namespace
   cidr                                   = var.vpc_cidr
   azs                                    = ["us-west-2a", "us-west-2b", "us-west-2c"]


### PR DESCRIPTION
[`terraform-aws-modules/vpc/aws` v3.8 drops support for terraform v0.12.x.](https://github.com/terraform-aws-modules/terraform-aws-vpc/pull/700#issuecomment-943658833). This is preventing us from deploying puppies infra until we update our terraform to v0.13.x.

It looks like Kyle was messing around with this module before he left - he released a handful of versions an ultimately removed the pin and I unfortunately don't know why. 

I'd like to create a 2.0.5 release with this change and update puppies infra to point at that.

A [search](https://github.com/search?q=org%3Asynapsestudios+terraform-aws-ecs-fargate-stack&type=code) for this module in our organization shows a couple projects are referencing it, but they are pinned to either a version or a commit, so looks like this change should be safe.